### PR TITLE
Rebuild Gemfile.lock for Leap

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,25 +12,29 @@ GEM
   specs:
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    bigdecimal (3.1.8)
     colorator (1.1.0)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.16.3)
+    ffi (1.17.0)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
-    google-protobuf (4.26.1)
+    google-protobuf (4.27.0)
+      bigdecimal
       rake (>= 13)
-    google-protobuf (4.26.1-aarch64-linux)
+    google-protobuf (4.27.0-arm64-darwin)
+      bigdecimal
       rake (>= 13)
-    google-protobuf (4.26.1-arm64-darwin)
+    google-protobuf (4.27.0-x86_64-darwin)
+      bigdecimal
       rake (>= 13)
-    google-protobuf (4.26.1-x86-linux)
-      rake (>= 13)
-    google-protobuf (4.26.1-x86_64-darwin)
-      rake (>= 13)
-    google-protobuf (4.26.1-x86_64-linux)
+    google-protobuf (4.27.0-x86_64-linux)
+      bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.0)
     i18n (1.14.5)
@@ -78,50 +82,20 @@ GEM
       strscan (>= 3.0.9)
     rouge (4.2.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.77.2)
+    sass-embedded (1.77.4)
       google-protobuf (>= 3.25, < 5.0)
-      rake (>= 13.0.0)
-    sass-embedded (1.77.2-aarch64-linux-android)
+      rake (>= 13)
+    sass-embedded (1.77.4-aarch64-mingw-ucrt)
       google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-aarch64-linux-gnu)
+    sass-embedded (1.77.4-arm64-darwin)
       google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-aarch64-linux-musl)
+    sass-embedded (1.77.4-x86-cygwin)
       google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-aarch64-mingw-ucrt)
+    sass-embedded (1.77.4-x86-mingw-ucrt)
       google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-arm-linux-androideabi)
+    sass-embedded (1.77.4-x86_64-cygwin)
       google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-arm-linux-gnueabihf)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-arm-linux-musleabihf)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-arm64-darwin)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-riscv64-linux-android)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-riscv64-linux-gnu)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-riscv64-linux-musl)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-x86-cygwin)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-x86-linux-android)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-x86-linux-gnu)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-x86-linux-musl)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-x86-mingw-ucrt)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-x86_64-cygwin)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-x86_64-darwin)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-x86_64-linux-android)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-x86_64-linux-gnu)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.2-x86_64-linux-musl)
+    sass-embedded (1.77.4-x86_64-darwin)
       google-protobuf (>= 3.25, < 5.0)
     strscan (3.1.0)
     terminal-table (3.0.2)
@@ -130,30 +104,14 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
-  aarch64-linux
-  aarch64-linux-android
-  aarch64-linux-gnu
-  aarch64-linux-musl
   aarch64-mingw-ucrt
-  arm-linux-androideabi
-  arm-linux-gnueabihf
-  arm-linux-musleabihf
   arm64-darwin
-  riscv64-linux-android
-  riscv64-linux-gnu
-  riscv64-linux-musl
   ruby
   x86-cygwin
-  x86-linux
-  x86-linux-android
-  x86-linux-gnu
-  x86-linux-musl
   x86-mingw-ucrt
   x86_64-cygwin
   x86_64-darwin
-  x86_64-linux
-  x86_64-linux-android
-  x86_64-linux-musl
+  x86_64-linux-gnu
 
 DEPENDENCIES
   jekyll


### PR DESCRIPTION
Older versions are needed for the production build on jekyll.i.o.o.